### PR TITLE
Found and Solved firefox issue with (nav-menu active) !!! :) 

### DIFF
--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -41,7 +41,7 @@
   list-style: none;
   text-align: center;
   width: 60vw;
-  justify-content: end;
+  justify-content: flex-start;
   margin-right: 2rem;
 }
 


### PR DESCRIPTION
Navbar.css Line 44 .nav-menu selector change -  justify-content: end; / !!!justify-content: flex-start;!!!
This change fixed issue in firefox with .nav-menu active going to the bottom...!!! 
Hurraaa! I could not sleep because of it few long nights! :P
