### PR TITLE
Accessibility improvement

### DIFF
--- a/src/components/CardItem.js
+++ b/src/components/CardItem.js
@@ -9,7 +9,7 @@ function CardItem(props) {
           <figure className='cards__item__pic-wrap' data-category={props.label}>
             <img
               className='cards__item__img'
-              alt='Travel Image'
+              alt={props.text}
               src={props.src}
             />
           </figure>


### PR DESCRIPTION
Change the image alt to {props.text} instead of 'Travel Image'. It can help the alt text to be different for each image according to text defined in Cards.js file and improve the accessibility, like screen readers.